### PR TITLE
Update MethodCallHandlerSharedPreferences.kt

### DIFF
--- a/android/src/main/kotlin/com/marlokessler/sharedpreferences/MethodCallHandlerSharedPreferences.kt
+++ b/android/src/main/kotlin/com/marlokessler/sharedpreferences/MethodCallHandlerSharedPreferences.kt
@@ -8,7 +8,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.AsyncTask
-import android.provider.ContactsContract.CommonDataKinds.StructuredName.PREFIX
 import android.util.Base64
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -28,6 +27,7 @@ internal class MethodCallHandlerSharedPreferences(private val context: Context) 
 
     companion object {
         // Fun fact: The following is a base64 encoding of the string "This is the prefix for a list."
+        private const val PREFIX ""
         private const val LIST_IDENTIFIER = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIGxpc3Qu"
         private const val BIG_INTEGER_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBCaWdJbnRlZ2Vy"
         private const val DOUBLE_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBEb3VibGUu"


### PR DESCRIPTION
PREFIX is wrongly being picked. We need to initialize to empty string for backward compatibility to android apps which use this feature. 