### PR TITLE
Update SharedPreferences.dart

### DIFF
--- a/lib/SharedPreferences.dart
+++ b/lib/SharedPreferences.dart
@@ -14,6 +14,12 @@ class SharedPreferences {
     reload();
   }
   
+  /// Fetches value from the host platform
+  /// Needs to be called before getting preferences. 
+  Future<void> init() async {
+    await reload();
+  }
+  
   static SharedPreferences standard = SharedPreferences();
 
   


### PR DESCRIPTION
static getInstance() is not a good idea as it will limit the users to use only one SP per application.
Better to call init() or reload().
Adding a new method init() to standardize this. 
Documentation should be updated as well if you accept these changes